### PR TITLE
完善了删除过期额度的方案，避免第二天继承上一天没使用完的额度

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM python:3.11.2-slim-bullseye
+FROM python:3.10.13-slim-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 COPY ./fonts/sarasa-mono-sc-regular.ttf /usr/share/fonts/
 
 RUN apt-get update && \
-    apt install --no-install-recommends xvfb binutils build-essential qtbase5-dev wkhtmltopdf ffmpeg -yq && \
+    apt install --no-install-recommends xvfb binutils build-essential qtbase5-dev wkhtmltopdf ffmpeg dbus -yq && \
     (strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5 || true) && \
     apt-get clean && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm -rf /var/lib/apt/lists/*
+
+RUN export DBUS_SESSION_BUS_ADDRESS=`dbus-daemon --fork --config-file=/usr/share/dbus-1/session.conf --print-address`
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/adapter/chatgpt/web.py
+++ b/adapter/chatgpt/web.py
@@ -102,7 +102,7 @@ class ChatGPTWebAdapter(BotAdapter):
                 logger.debug(f"[ChatGPT-Web] {last_response['conversation_id']} - {last_response['message']}")
         except AttributeError as e:
             if str(e).startswith("'str' object has no attribute 'get'"):
-                yield "出现故障，请发送”{reset}“重新开始！".format(reset=config.trigger.reset_command)
+                yield "出现故障，请发送“{reset}”重新开始！".format(reset=config.trigger.reset_command)
         except revChatGPT.typings.Error as e:
             if e.code == 429:
                 current_time = datetime.datetime.now()

--- a/adapter/common/chat_helper.py
+++ b/adapter/common/chat_helper.py
@@ -1,0 +1,9 @@
+ROLE_USER: str = "user"
+ROLE_ASSISTANT: str = "assistant"
+
+
+class ChatMessage:
+
+    def __init__(self, role: str, content: str):
+        self.role = role
+        self.content = content

--- a/adapter/gpt4free/g4f_helper.py
+++ b/adapter/gpt4free/g4f_helper.py
@@ -9,7 +9,7 @@ def g4f_check_account(account: G4fModels):
 
     try:
         response = g4f.ChatCompletion.create(
-            model=account.model,
+            model=eval(account.model) if account.model.startswith("g4f.models.") else account.model,
             provider=eval(account.provider),
             messages=[vars(ChatMessage(ROLE_USER, "hello"))],
         )

--- a/adapter/gpt4free/g4f_helper.py
+++ b/adapter/gpt4free/g4f_helper.py
@@ -1,0 +1,32 @@
+import g4f
+from loguru import logger
+
+from adapter.common.chat_helper import ChatMessage, ROLE_USER
+from config import G4fModels
+
+
+def g4f_check_account(account: G4fModels):
+
+    try:
+        response = g4f.ChatCompletion.create(
+            model=account.model,
+            provider=eval(account.provider),
+            messages=[vars(ChatMessage(ROLE_USER, "hello"))],
+        )
+        logger.debug(f"g4f model ({vars(account)}) is active. hello -> {response}")
+    except KeyError as e:
+        logger.debug(f"g4f model ({vars(account)}) is inactive. hello -> {e}")
+        return False
+    return True
+
+
+def parse(model_alias: str):
+    from constants import botManager
+    return next(
+        (
+            model
+            for model in botManager.bots["gpt4free"]
+            if model_alias == model.alias
+        ),
+        None
+    )

--- a/adapter/gpt4free/gpt4free.py
+++ b/adapter/gpt4free/gpt4free.py
@@ -1,0 +1,37 @@
+from typing import Generator
+
+import g4f
+
+from adapter.botservice import BotAdapter
+from adapter.common.chat_helper import ChatMessage, ROLE_ASSISTANT, ROLE_USER
+from config import G4fModels
+from constants import botManager
+
+
+class Gpt4FreeAdapter(BotAdapter):
+    """实例"""
+
+    def __init__(self, session_id: str = "unknown", model: G4fModels = None):
+        super().__init__(session_id)
+        self.session_id = session_id
+        self.model = model or botManager.pick("gpt4free")
+        self.conversation_history = []
+
+    async def rollback(self):
+        if len(self.conversation_history) <= 0:
+            return False
+        self.conversation_history = self.conversation_history[:-1]
+        return True
+
+    async def on_reset(self):
+        self.conversation_history = []
+
+    async def ask(self, prompt: str) -> Generator[str, None, None]:
+        self.conversation_history.append(vars(ChatMessage(ROLE_USER, prompt)))
+        response = g4f.ChatCompletion.create(
+            model=self.model.model,
+            provider=eval(self.model.provider),
+            messages=self.conversation_history,
+        )
+        self.conversation_history.append(vars(ChatMessage(ROLE_ASSISTANT, response)))
+        yield response

--- a/adapter/gpt4free/gpt4free.py
+++ b/adapter/gpt4free/gpt4free.py
@@ -29,7 +29,7 @@ class Gpt4FreeAdapter(BotAdapter):
     async def ask(self, prompt: str) -> Generator[str, None, None]:
         self.conversation_history.append(vars(ChatMessage(ROLE_USER, prompt)))
         response = g4f.ChatCompletion.create(
-            model=self.model.model,
+            model=eval(self.model.model) if self.model.model.startswith("g4f.models.") else self.model.model,
             provider=eval(self.model.provider),
             messages=self.conversation_history,
         )

--- a/adapter/quora/poe.py
+++ b/adapter/quora/poe.py
@@ -1,8 +1,8 @@
+import asyncio
 import time
 from enum import Enum
 from typing import Generator
 
-import asyncio
 from loguru import logger
 from poe import Client as PoeClient
 

--- a/config.example.cfg
+++ b/config.example.cfg
@@ -21,6 +21,13 @@ access_token = "这里填写你的 access_token（其他接入方式请看教程
 # 国内用户可能需要配置代理
 # proxy="http://127.0.0.1:7890"
 
+[gpt4free]
+[[gpt4free.accounts]]
+provider = 'g4f.Provider.GetGpt'
+model = 'gpt-3.5-turbo'
+alias = 'g4f-chatgpt'
+description = 'gpt4free的gpt-3.5-turbo'
+
 [presets]
 # 切换预设的命令： 加载预设 猫娘
 command = "加载预设 (\\w+)"

--- a/config.example.cfg
+++ b/config.example.cfg
@@ -22,10 +22,15 @@ access_token = "这里填写你的 access_token（其他接入方式请看教程
 # proxy="http://127.0.0.1:7890"
 
 [gpt4free]
+# 可配置的模型，参考：https://github.com/xtekky/gpt4free#models
 [[gpt4free.accounts]]
+# 参考：https://github.com/xtekky/gpt4free#models，注意Provider需要首字母大写！
 provider = 'g4f.Provider.GetGpt'
+# 参考：https://github.com/xtekky/gpt4free#models
 model = 'gpt-3.5-turbo'
+# 切换AI用的名字，例如： 切换AI g4f-chatgpt
 alias = 'g4f-chatgpt'
+# ping bot时针对此AI的描述
 description = 'gpt4free的gpt-3.5-turbo'
 
 [presets]

--- a/config.py
+++ b/config.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
-from typing import List, Union, Literal, Dict, Optional
-from pydantic import BaseModel, BaseConfig, Extra
-from charset_normalizer import from_bytes
-from loguru import logger
+
 import os
 import sys
+from typing import List, Union, Literal, Dict, Optional
+
 import toml
+from charset_normalizer import from_bytes
+from loguru import logger
+from pydantic import BaseModel, BaseConfig, Extra
 
 
 class Onebot(BaseModel):
@@ -259,6 +261,22 @@ class ChatGLMAPI(BaseModel):
 class ChatGLMAuths(BaseModel):
     accounts: List[ChatGLMAPI] = []
     """ChatGLM的账号列表"""
+
+
+class G4fModels(BaseModel):
+    provider: str
+    """ai提供方"""
+    model: str
+    """ai模型"""
+    alias: str
+    """模型缩写"""
+    description: str
+    """介绍"""
+
+
+class G4fAuths(BaseModel):
+    accounts: List[G4fModels] = []
+    """支持的模型"""
 
 
 class SlackAppAccessToken(BaseModel):
@@ -544,6 +562,7 @@ class Config(BaseModel):
     poe: PoeAuths = PoeAuths()
     slack: SlackAuths = SlackAuths()
     xinghuo: XinghuoAuths = XinghuoAuths()
+    gpt4free: G4fAuths = G4fAuths()
 
     # === Response Settings ===
     text_to_image: TextToImage = TextToImage()

--- a/conversation.py
+++ b/conversation.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 import time
 from datetime import datetime
@@ -10,28 +9,29 @@ from graia.amnesia.message import MessageChain
 from graia.ariadne.message.element import Image as GraiaImage, Element
 from loguru import logger
 
-import constants
 from adapter.baidu.yiyan import YiyanAdapter
 from adapter.botservice import BotAdapter
 from adapter.chatgpt.api import ChatGPTAPIAdapter
 from adapter.chatgpt.web import ChatGPTWebAdapter
 from adapter.claude.slack import ClaudeInSlackAdapter
 from adapter.google.bard import BardAdapter
+from adapter.gpt4free.g4f_helper import parse as g4f_parse
+from adapter.gpt4free.gpt4free import Gpt4FreeAdapter
 from adapter.ms.bing import BingAdapter
-from adapter.xunfei.xinghuo import XinghuoAdapter
-from drawing import DrawingAPI, SDWebUI as SDDrawing, OpenAI as OpenAIDrawing
 from adapter.quora.poe import PoeBot, PoeAdapter
 from adapter.thudm.chatglm_6b import ChatGLM6BAdapter
+from adapter.xunfei.xinghuo import XinghuoAdapter
+from constants import LlmName
 from constants import config
+from drawing import DrawingAPI, SDWebUI as SDDrawing, OpenAI as OpenAIDrawing
 from exceptions import PresetNotFoundException, BotTypeNotFoundException, NoAvailableBotException, \
     CommandRefusedException, DrawingFailedException
+from middlewares.draw_ratelimit import MiddlewareRatelimit
 from renderer import Renderer
 from renderer.merger import BufferedContentMerger, LengthContentMerger
 from renderer.renderer import MixedContentMessageChainRenderer, MarkdownImageRenderer, PlainTextRenderer
 from renderer.splitter import MultipleSegmentSplitter
-from middlewares.draw_ratelimit import MiddlewareRatelimit
 from utils import retry
-from constants import LlmName
 from utils.text_to_speech import TtsVoice, TtsVoiceManager
 
 handlers = {}
@@ -110,6 +110,8 @@ class ConversationContext:
             self.adapter = ClaudeInSlackAdapter(self.session_id)
         elif _type == LlmName.XunfeiXinghuo.value:
             self.adapter = XinghuoAdapter(self.session_id)
+        elif g4f_parse(_type):
+            self.adapter = Gpt4FreeAdapter(self.session_id, g4f_parse(_type))
         else:
             raise BotTypeNotFoundException(_type)
         self.type = _type

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ httpx~=0.24.1
 Quart==0.17.0
 pydub~=0.25.1
 httpcore~=0.17.3
+g4f~=0.0.2.6


### PR DESCRIPTION
前段时间给用户使用的过程中发现一个问题（我设置所有用户的额度为20条/小时），如果某用户第一天晚上八点时对话了18条，且九点后一直到次日八点这个用户没有继续进行对话，那么第二天八点时，该用户将继承这个18/20的使用额度，导致该用户在今天八点时只能对话2条。因此对于`chatgpt-mirai-qq-bot/manager/ratelimit.py`函数进行修改：
- 在rate_usage.json数据库中，记录`day`的属性。初始化时，`usage = {'type': _type, 'id': _id, 'count': 0, 'time': current_time, 'day': current_day}`
- 在`get_usage`函数中，添加了根据天数`day`删除过期的记录的判断方案。